### PR TITLE
fix showing wrong name in localsettings

### DIFF
--- a/draw.js
+++ b/draw.js
@@ -732,7 +732,7 @@ settings: function(settings, onchange) {
 		var type = data.type
 		var elem
 		var label = document.createElement('label')
-		label.textContent = data.title+": "
+		label.textContent = data.name+": "
 		x.elem.appendChild(label)
 		if (type=='select') {
 			elem = document.createElement('select')


### PR DESCRIPTION
before: ![undefined: light](http://newdev.smilebasicsource.com/api/File/raw/2011)
now: ![Theme: light](https://newdev.smilebasicsource.com/api/File/raw/2014)