### PR TITLE
style: ruby text should ignore white-space: pre-wrap

### DIFF
--- a/markup.css
+++ b/markup.css
@@ -88,6 +88,10 @@
 	margin: 0.25em 0;
 }
 
+.markup-root ruby {
+	white-space: normal;
+}
+
 .markup-root ol {
 	margin-left: 2em;
 	padding-left: 0;


### PR DESCRIPTION
![example behavior with and without white-space: pre-wrap](https://user-images.githubusercontent.com/12588017/132763141-8b143c1a-3d60-421a-b439-734dbe3222aa.png)
