### PR TITLE
Ignore List and Comment Filters

### DIFF
--- a/chat.js
+++ b/chat.js
@@ -161,6 +161,14 @@ ChatRoom.generateListeners = function(old) {
 }
 
 ChatRoom.markup = "12y"
+ChatRoom.ignoredUserIds = []
+ChatRoom.filters = []
+
+ChatRoom.filterComments = function(comments) {
+		return comments.filter(x =>
+				!ChatRoom.ignoredUserIds.includes(x.createUserId) &&
+		    (ChatRoom.filters.find(y => x.content.match(y)) === undefined))
+}
 
 ChatRoom.prototype.loadOlder = function(num, callback) {
 	var $=this
@@ -420,6 +428,8 @@ ChatRoom.prototype.shouldScroll = function() {
 }
 
 ChatRoom.prototype.displayMessage = function(comment, autoscroll) {
+	if (ChatRoom.ignoredUserIds.includes(comment.createUserId))
+			return
 	var $=this
 	this.scroller.handlePrint(function() {
 		var old = $.messageElements[comment.id]

--- a/draw.js
+++ b/draw.js
@@ -114,8 +114,12 @@ userList: function() {
 
 userListAvatar: function(status) {
 	var a = linkAvatar(status.user)
+	if (ChatRoom.ignoredUserIds.includes(status.user.id))
+			a.className += " status-ignored"
 	if (status.status == "idle")
 		a.className += " status-idle"
+	a.setAttribute('data-uid', status.user.id)
+	a.classList.add('avatar-link')
 	return a
 },
 

--- a/main.js
+++ b/main.js
@@ -27,6 +27,7 @@ Req.onLogin = function() {
 	// display user info etc.
 	// start long poller
 	Req.onMessages = function(comments, contents) {
+		comments = ChatRoom.filterComments(comments)
 		ChatRoom.displayMessages(comments)
 		Act.newComments(comments, Entity.makePageMap(contents))
 		Sidebar.onAggregateChange(Act.items)

--- a/request.js
+++ b/request.js
@@ -253,6 +253,7 @@ read: function(requests, filters, callback, needCategories) {
 			if (needCategories)
 				gotCategoryTree = true
 		}
+		resp.comment = ChatRoom.filterComments(resp.comment)
 		callback(e, resp)
 	})
 },
@@ -405,6 +406,8 @@ getRecentActivity: function(callback) {
 		content: "name,id,permissions,type"
 	}, function(e, resp) {
 		console.log(resp)
+		// filter out all of the comments that have ignored users in them
+		resp.comment = ChatRoom.filterComments(resp.comment)
 		if (!e)
 			callback(resp.activity, resp.commentaggregate, resp.Awatching, resp.CAwatching, resp.content, resp.comment.reverse())
 		else
@@ -427,8 +430,8 @@ getComment: function(id, callback) {
 	return read([
 		{comment: {ids: [id]}}//todo: maybe also get page permissions?
 	], {}, function(e, resp) {
-		if (!e)
-			callback(resp.comment[0])
+		if (!e)			
+			callback(ChatRoom.filterComments(resp.comment[0]))
 		else
 			callback(null)
 	})

--- a/settings.js
+++ b/settings.js
@@ -54,6 +54,45 @@ fields: {
 			ChatRoom.nickname = value.substr(0, 50).replace(/\n/g, "  ");
 		},
 	},
+	chatIgnored: {
+			name: "Ignored Users",
+			autosave: false,
+			type: 'textarea',
+			update: function(value) {
+				Array.prototype.partition = function(isValid) {
+					return this.reduce(([pass, fail], elem) => {
+						return isValid(elem) ? [[...pass, elem], fail] : [pass, [...fail, elem]];
+					}, [[], []]);
+				}
+				ChatRoom.ignoredUserIds = value.split(',').map(x => parseInt(x)) || []
+				// hide all "message-block"s that have the user inside of them
+				let msg = document.querySelectorAll('message-block')
+				Array
+					.from(msg)
+					.filter(x => ChatRoom
+										.ignoredUserIds
+										.includes(parseInt(x.getAttribute('data-uid'))))
+					.map(x => x.remove())
+				let avatar = document.querySelectorAll('a.avatar-link')
+				let [ignoredAvs, unignoredAvs] =Array
+						.from(avatar)
+						.partition(x => ChatRoom
+											 .ignoredUserIds
+											 .includes(parseInt(x.getAttribute('data-uid'))))
+				ignoredAvs.map(x => x.classList.add('status-ignored'))
+				unignoredAvs.map(x => x.classList.remove('status-ignored'))
+			},
+	},
+	chatFilters: {
+			name: "Comment Filters",
+			autosave: false,
+			type: 'textarea',
+			update: function(value) {
+					ChatRoom.filters = value.split(/\r?\n/)
+							.filter(x => x !== '')
+							.map(x => new RegExp(x, 'g'))
+			}
+	}
 },
 
 change: function(name, value) {

--- a/style.css
+++ b/style.css
@@ -436,6 +436,14 @@ html:not(.f-sidebarUploaded) .sidebarUploadedFile {
 	filter: grayscale(1);
 }
 
+.status-ignored > .avatar {
+	filter: sepia(100%);
+}
+
+.message-ignored-user, .message-ignored-filter {
+	display: none;
+}
+
 html.f-loading .loadBG {
 	background: var(--loading-invert-bg);
 }


### PR DESCRIPTION
In the settings, I have added two new features for brain damage chat filtering.
![Screenshot of Settings with Ignore List and Comment _Filters](https://user-images.githubusercontent.com/18371895/133004968-18c8b722-a814-44a9-b5a7-32e52c1f76cb.png)_
The settings are only applied once you click the Save Settings button.

The users are separated by commas by their IDs and the filters are regexes with the global rule that are separated by newlines. Saving the settings will delete created by the user immediately and filter all requests from them until they are removed as well as adds a sepia filter to their avatar. It isn't clean and could be improved.

While controversial, in order to decrease activity as much as possible and "wipe them" (which is what I prefer, even if it means refreshing), it works at the request level rather than having a convenient toggle. If this is not desired and you would rather a more convenient toggle interface, then I can work on doing that, but this is my proposed solution for right now.