### PR TITLE
don't display separator if the pinned values list is empty

### DIFF
--- a/src/Views/page.js
+++ b/src/Views/page.js
@@ -124,7 +124,7 @@ class PageView extends BaseView {
 		this.pinned = false
 		this.scroller = new Scroller(this.$outer, this.$inner)
 		
-		if (pinned) {
+		if (pinned instanceof Array && pinned.length > 0) {
 			let pinned_separator = document.createElement('div')
 			pinned_separator.className = "messageGap"
 			this.$extra.prepend(pinned_separator)


### PR DESCRIPTION
I only just realized this I'm sorry this is a separate PR lol