### PR TITLE
add text-to-speech reading of messages

### DIFF
--- a/index.html
+++ b/index.html
@@ -266,7 +266,7 @@
 				<button onclick='RELOAD()'>Reload</button>
 				<button onclick='Lp.start_websocket(true)'>Reset Socket</button>
 				<button onclick='for(let sheet of document.styleSheets)if(sheet.href)sheet.ownerNode.href+="#"'>reload css</button>
-				<button onclick='TTSSystem.cancel()'>Stop TTS</button>
+				<button onclick='TTSSystem.cancel()' onmouseover='this.title = `${TTSSystem.queue.length} messages in TTS queue`'>Stop TTS</button>
 				
 				<button id=$logOut style="float:right">Log out</button>
 			</div>

--- a/index.html
+++ b/index.html
@@ -158,6 +158,8 @@
 <script src=src/draw.js></script>
 <script src=src/input.js></script>
 
+<script src=src/tts.js></script>
+
 <script src=src/debug.js></script>
 <script src=src/view.js></script>
 <script src=src/settings.js></script>

--- a/index.html
+++ b/index.html
@@ -266,6 +266,7 @@
 				<button onclick='RELOAD()'>Reload</button>
 				<button onclick='Lp.start_websocket(true)'>Reset Socket</button>
 				<button onclick='for(let sheet of document.styleSheets)if(sheet.href)sheet.ownerNode.href+="#"'>reload css</button>
+				<button onclick='TTSSystem.cancel()'>Stop TTS</button>
 				
 				<button id=$logOut style="float:right">Log out</button>
 			</div>

--- a/src/Views/page.js
+++ b/src/Views/page.js
@@ -227,8 +227,9 @@ class PageView extends BaseView {
 		}
 	}
 	static title_notification(comment) {
-		if (Settings.values['tts_notify']=='yes')
-			TTSSystem.speakMessage(comment)
+		if (Settings.values['tts_notify']!='no')
+			if (Settings.values['tts_notify']=='yes' || comment.createUserId != Req.uid)
+				TTSSystem.speakMessage(comment)
 		
 		View.title_notification(comment.text, Draw.avatar_url(comment.Author))
 		// todo: also call if the current comment being shown in the title is edited

--- a/src/Views/page.js
+++ b/src/Views/page.js
@@ -227,7 +227,7 @@ class PageView extends BaseView {
 		}
 	}
 	static title_notification(comment) {
-		if (Settings.values.speak_new_message == "on")
+		if (Settings.values['tts_notify']=='yes')
 			TTSSystem.speakMessage(comment)
 		
 		View.title_notification(comment.text, Draw.avatar_url(comment.Author))

--- a/src/Views/page.js
+++ b/src/Views/page.js
@@ -228,7 +228,7 @@ class PageView extends BaseView {
 	}
 	static title_notification(comment) {
 		if (Settings.values.speak_new_message == "on")
-			speakMessage(comment)
+			TTSSystem.speakMessage(comment)
 		
 		View.title_notification(comment.text, Draw.avatar_url(comment.Author))
 		// todo: also call if the current comment being shown in the title is edited

--- a/src/Views/page.js
+++ b/src/Views/page.js
@@ -227,6 +227,9 @@ class PageView extends BaseView {
 		}
 	}
 	static title_notification(comment) {
+		if (Settings.values.speak_new_message == "on")
+			speakMessage(comment)
+		
 		View.title_notification(comment.text, Draw.avatar_url(comment.Author))
 		// todo: also call if the current comment being shown in the title is edited
 	}

--- a/src/chat.js
+++ b/src/chat.js
@@ -5,6 +5,8 @@
 document.addEventListener('message_control', e=>{
 	if (e.detail.action=='info')
 		alert(JSON.stringify(e.detail.data, null, 1)) // <small heart>
+	if (e.detail.action=='speak')
+		speakMessage(e.detail.data)
 })
 
 class MessageList {

--- a/src/chat.js
+++ b/src/chat.js
@@ -6,7 +6,7 @@ document.addEventListener('message_control', e=>{
 	if (e.detail.action=='info')
 		alert(JSON.stringify(e.detail.data, null, 1)) // <small heart>
 	if (e.detail.action=='speak')
-		speakMessage(e.detail.data)
+		TTSSystem.speakMessage(e.detail.data)
 })
 
 class MessageList {

--- a/src/draw.js
+++ b/src/draw.js
@@ -455,7 +455,7 @@ const Draw = Object.seal({
 	
 	message_controls: function(cb) {
 		let e = this()
-		e.firstChild.onclick = e=>cb(e, 'info')
+		e.firstChild.onclick = e=>cb(e, e.shiftKey ? 'speak' : 'info')
 		e.lastChild.onclick = e=>cb(e, 'edit')
 		return {elem: e}
 	}.bind(𐀶`<message-controls><button tab-index=-1>⚙</button><button tab-index=-1>✏</button>`),

--- a/src/settings.js
+++ b/src/settings.js
@@ -45,7 +45,7 @@ Settings.fields = {
 	tts_notify: {
 		name: "TTS Notify",
 		type: 'select',
-		options: ['no', 'yes'],
+		options: ['no', 'everyone else', 'yes'],
 	},
 	// tts_voice: {
 	// 	name: "TTS Voice",

--- a/src/settings.js
+++ b/src/settings.js
@@ -60,7 +60,8 @@ Settings.fields = {
 		notches: [0.1, 0.2, 0.3, 0.4, 0.5, 0.6, 0.7, 0.8, 0.9], // 🥴
 		update(value) {
 			if (document.readyState != 'loading') {
-				TTSSystem.voiceParams.volume = value
+				TTSSystem.cancel()
+				TTSSystem.synthParams.volume = value
 				TTSSystem.speakMessage({text:"{#uwu",values:{m:'12y'}}, true)
 			}
 		},
@@ -73,8 +74,8 @@ Settings.fields = {
 		notches: [1],
 		update(value) {
 			if (document.readyState != 'loading') {
-				TTSSystem.voiceParams.rate = value
-				speechSynthesis.cancel()
+				TTSSystem.cancel()
+				TTSSystem.synthParams.rate = value
 				TTSSystem.speakMessage({text:"example message",values:{m:'plaintext'}}, true)
 			}
 		},

--- a/src/settings.js
+++ b/src/settings.js
@@ -42,18 +42,42 @@ Settings.fields = {
 			})*/
 		},
 	},
-	speak_new_message: {
-		name: "speak new messages",
+	tts_notify: {
+		name: "TTS Notify",
 		type: 'select',
-		options: ['off', 'on'],
+		options: ['no', 'yes'],
+	},
+	// tts_voice: {
+	// 	name: "TTS Voice",
+	// 	type: 'select',
+	// 	options: ['none'],
+	// },
+	tts_volume: {
+		name: "TTS Volume",
+		type: 'range',
+		range: [0.0, 1.0],
+		step: 'any',
+		notches: [0.1, 0.2, 0.3, 0.4, 0.5, 0.6, 0.7, 0.8, 0.9], // 🥴
 		update(value) {
-			if (value=='on' && !speechSynthesis.getVoices().length) {
-				alert("warning! your device does not have tts voices. sorry")
-				// Settings.change('speak_new_message', 'off')
-				// is ^this^ okay? does this run during load?
-				// ...it's not okay! : )
+			if (document.readyState != 'loading') {
+				TTSSystem.voiceParams.volume = value
+				TTSSystem.speakMessage({text:"{#uwu",values:{m:'12y'}}, true)
 			}
-		}
+		},
+	},
+	tts_speed: {
+		name: "TTS Speed",
+		type: 'range',
+		range: [0.5, 2], // (heard range may be narrower)
+		step: 'any',
+		notches: [1],
+		update(value) {
+			if (document.readyState != 'loading') {
+				TTSSystem.voiceParams.rate = value
+				speechSynthesis.cancel()
+				TTSSystem.speakMessage({text:"example message",values:{m:'plaintext'}}, true)
+			}
+		},
 	},
 	lazy_loading: {
 		name: "lazy image loading",
@@ -163,7 +187,25 @@ Settings.draw = function() {
 			elem = document.createElement('textarea')
 		} else if (type=='text') {
 			elem = document.createElement('input')
+		} else if (type=='range') {
+			elem = document.createElement('input')
+			elem.type = 'range'
+			elem.min = data.range[0]; elem.max = data.range[1]
+			elem.step = data.step || 'any'
+			if (data.notches) {
+				let great = row.child('datalist')
+				great.style.display = 'none'
+				for (let e of data.notches.concat(data.range)) {
+					let opt = great.child('option')
+					opt.value = e
+				}
+				elem.setAttribute('list', great.id = `settings_panel__${name}_datalist`)
+			}
 		}
+		
+		// connect label to element (feels nice)
+		elem.id = `settings_panel__${name}`
+		label.htmlFor = elem.id
 		
 		get[name] = ()=>{
 			return elem.value

--- a/src/settings.js
+++ b/src/settings.js
@@ -56,27 +56,27 @@ Settings.fields = {
 		name: "TTS Volume",
 		type: 'range',
 		range: [0.0, 1.0],
-		step: 'any',
+		step: 1/20,
 		notches: [0.1, 0.2, 0.3, 0.4, 0.5, 0.6, 0.7, 0.8, 0.9], // 🥴
-		update(value) {
-			if (document.readyState != 'loading') {
+		update(value, event) {
+			TTSSystem.synthParams.volume = value
+			if (event && event.type == 'change') {
 				TTSSystem.cancel()
-				TTSSystem.synthParams.volume = value
 				if (TTSSystem.placeholderSound) TTSSystem.speakMessage({text:"{#uwu",values:{m:'12y'}}, true)
 				else TTSSystem.speakMessage({text:"example message",values:{m:'plaintext'}}, true)
 			}
-		},
+		}
 	},
 	tts_speed: {
 		name: "TTS Speed",
 		type: 'range',
 		range: [0.5, 2], // (heard range may be narrower)
-		step: 'any',
+		step: 1/20,
 		notches: [1],
-		update(value) {
-			if (document.readyState != 'loading') {
+		update(value, event) {
+			TTSSystem.synthParams.rate = value
+			if (event && event.type == 'change') {
 				TTSSystem.cancel()
-				TTSSystem.synthParams.rate = value
 				TTSSystem.speakMessage({text:"example message",values:{m:'plaintext'}}, true)
 			}
 		},
@@ -146,22 +146,22 @@ Settings.early = function() {
 },
 
 // change a setting after load
-Settings.change = function(name, value) {
+Settings.change = function(name, value, event) {
 	let field = this.fields[name]
 	if (!field)
 		return
 	this.values[name] = value
 	localStorage.setItem("setting-"+name, JSON.stringify(value))
-	field.update && field.update(value)
+	field.update && field.update(value, event)
 }
 
 // todo: replace this
 Settings.draw = function() {
 	let settings = Settings
 	let get = {}
-	let update = (name)=>{
+	let update = (name, event)=>{
 		let value = get[name]()
-		settings.change(name, value)
+		settings.change(name, value, event)
 	}
 	let x = {
 		elem: document.createDocumentFragment(),
@@ -195,13 +195,12 @@ Settings.draw = function() {
 			elem.min = data.range[0]; elem.max = data.range[1]
 			elem.step = data.step || 'any'
 			if (data.notches) {
-				let great = row.child('datalist')
-				great.style.display = 'none'
+				let notches = row.child('datalist')
 				for (let e of data.notches.concat(data.range)) {
-					let opt = great.child('option')
+					let opt = notches.child('option')
 					opt.value = e
 				}
-				elem.setAttribute('list', great.id = `settings_panel__${name}_datalist`)
+				elem.setAttribute('list', notches.id = `settings_panel__${name}_datalist`)
 			}
 		}
 		
@@ -217,8 +216,8 @@ Settings.draw = function() {
 		elem.value = value
 		
 		if (data.autosave != false)
-			elem.onchange = ()=>{
-				update(name)
+			elem.onchange = (event)=>{
+				update(name, event)
 			}
 		
 		elem && row.append(elem)

--- a/src/settings.js
+++ b/src/settings.js
@@ -62,7 +62,8 @@ Settings.fields = {
 			if (document.readyState != 'loading') {
 				TTSSystem.cancel()
 				TTSSystem.synthParams.volume = value
-				TTSSystem.speakMessage({text:"{#uwu",values:{m:'12y'}}, true)
+				if (TTSSystem.placeholderSound) TTSSystem.speakMessage({text:"{#uwu",values:{m:'12y'}}, true)
+				else TTSSystem.speakMessage({text:"example message",values:{m:'plaintext'}}, true)
 			}
 		},
 	},

--- a/src/settings.js
+++ b/src/settings.js
@@ -42,6 +42,19 @@ Settings.fields = {
 			})*/
 		},
 	},
+	speak_new_message: {
+		name: "speak new messages",
+		type: 'select',
+		options: ['off', 'on'],
+		update(value) {
+			if (value=='on' && !speechSynthesis.getVoices().length) {
+				alert("warning! your device does not have tts voices. sorry")
+				// Settings.change('speak_new_message', 'off')
+				// is ^this^ okay? does this run during load?
+				// ...it's not okay! : )
+			}
+		}
+	},
 	lazy_loading: {
 		name: "lazy image loading",
 		type: 'select',

--- a/src/tts.js
+++ b/src/tts.js
@@ -270,5 +270,3 @@ const TTSSystem = {
 		this.current = null
 	}
 }
-
-// (from quick run through of 12y markup guide and glance at comments)

--- a/src/tts.js
+++ b/src/tts.js
@@ -1,200 +1,213 @@
 'use strict'
 
-let TTSSystem = {}
-
-function speakUtterance(u) {
-	return new Promise((yay, nay) => {
-		u.addEventListener('end', e=>(e.charIndex < e.target.length) ? nay(e) : yay())
-		u.addEventListener('error', e=>nay(e))
-		speechSynthesis.speak(u)
-	})
-}
-
-function lastOfMetaUtterance(mu) {
-	let last = mu[mu.length - 1]
-	if (last instanceof SpeechSynthesisUtterance) {
+const TTSSystem = {
+	speakUtterance(u) {
 		return new Promise((yay, nay) => {
-			last.addEventListener('end', e=>(e.charIndex < e.target.length) ? nay(e) : yay())
-			last.addEventListener('error', e=>nay(e))
+			u.addEventListener('end', e=>(e.charIndex < e.target.length) ? nay(e) : yay())
+			u.addEventListener('error', e=>nay(e))
+			speechSynthesis.speak(u)
 		})
-	} else if (last instanceof HTMLAudioElement) {
+	},
+	
+	lastOfMetaUtterance(mu) {
+		let last = mu[mu.length - 1]
+		if (last instanceof SpeechSynthesisUtterance) {
+			return new Promise((yay, nay) => {
+				last.addEventListener('end', e=>(e.charIndex < e.target.length) ? nay(e) : yay())
+				last.addEventListener('error', e=>nay(e))
+			})
+		} else if (last instanceof HTMLAudioElement) {
+			return new Promise((yay, nay) => {
+				let removeListeners
+				
+				let c_ended = e=>yay(removeListeners())
+				let c_error = e=>nay(e,removeListeners())
+				
+				last.addEventListener('ended', c_ended)
+				// last.addEventListener('', c_error)
+				last.addEventListener('error', c_error)
+				
+				removeListeners = ()=>{
+					last.removeEventListener('ended', c_ended)
+					last.removeEventListener('error', c_error)
+				}
+			})
+		}
+	},
+	
+	loadSound(path) {
+		let s = new Audio(path)
+		s.loop = false; s.load()
+		return s
+	},
+	
+	playSound(s) {
 		return new Promise((yay, nay) => {
 			let removeListeners
 			
 			let c_ended = e=>yay(removeListeners())
 			let c_error = e=>nay(e,removeListeners())
+			let c_loadeddata = e=>((s.readyState >= HTMLMediaElement) && s.play())
 			
-			last.addEventListener('ended', c_ended)
-			last.addEventListener('', c_error)
-			last.addEventListener('error', c_error)
+			s.addEventListener('ended', c_ended)
+			s.addEventListener('error', c_error)
 			
 			removeListeners = ()=>{
-				last.removeEventListener('ended', c_ended)
-				last.removeEventListener('error', c_error)
+				s.removeEventListener('ended', c_ended)
+				s.removeEventListener('error', c_error)
+				s.removeEventListener('loadeddata', c_loadeddata)
+			}
+			
+			if (s.readyState < HTMLMediaElement.HAVE_ENOUGH_DATA && !(s.currentTime > 0)) {
+				s.addEventListener('loadeddata', c_loadeddata)
+			} else {
+				// TODO: play a placeholder sound if sound too long (>25s?)
+				s.currentTime = 0; s.play()
 			}
 		})
-	}
-}
-
-function loadSound(path) {
-	let s = new Audio(path)
-	s.loop = false; s.load()
-	return s
-}
-
-function playSound(s) {
-	return new Promise((yay, nay) => {
-		let removeListeners
+	},
+	
+	async speakMessage(message, merged = false) {
+		let tree = Markup.langs.parse(message.text, message.values.m)
 		
-		let c_ended = e=>yay(removeListeners())
-		let c_error = e=>nay(e,removeListeners())
-		let c_loadeddata = e=>{console.log(s.readyState); return ((s.readyState >= HTMLMediaElement) && s.play())}
+		let author = message.Author
+		let memorable_name = author.bridge ? (author.nickname || message.values.b) : author.username
+		let msg = merged ? "" : `${memorable_name} says\n`
 		
-		s.addEventListener('ended', c_ended)
-		s.addEventListener('error', c_error)
+		this.speakScript(this.renderSpeechScript(tree, { msg }))
+	},
+	
+	queue: [],
+	async speakScript(utter) {
+		this.queue.push(utter)
+		if (this.queue.length - 1)
+			await this.lastOfMetaUtterance(this.queue[this.queue.length - 2])
 		
-		removeListeners = ()=>{
-			s.removeEventListener('ended', c_ended)
-			s.removeEventListener('error', c_error)
-			s.removeEventListener('loadeddata', c_loadeddata)
+		for (let u of utter) {
+			if (u instanceof SpeechSynthesisUtterance) await this.speakUtterance(u)
+			else if (u instanceof HTMLAudioElement) await this.playSound(u)
 		}
 		
-		if (s.readyState < HTMLMediaElement.HAVE_ENOUGH_DATA && !(s.currentTime > 0)) {
-			s.addEventListener('loadeddata', c_loadeddata)
-		} else {
-			// TODO: play a placeholder sound if sound too long (>25s?)
-			s.currentTime = 0; s.play()
+		// sloppy
+		this.queue.shift()
+	},
+	
+	// creates a list of smaller utterances and media to play in sequence
+	renderSpeechScript(tree, opts = {}) {
+		opts.msg ||= ""
+		opts.pitch ||= 1.0
+		opts.rate ||= 1.25
+		opts.utter ||= []
+		// if (opts.abridged == undefined) opts.abridged = true
+		// Would it be nice to just have a way of reading the entire message
+		// without skipping over complex parts (full URLs, code blocks, table)?
+		
+		function finalizeChunk() {
+			opts.msg = opts.msg.trim()
+			if (!opts.msg.length) return
+			let u = new SpeechSynthesisUtterance(opts.msg)
+			u.pitch = opts.pitch; u.rate = opts.rate
+			opts.utter.push(u); opts.msg = ""
 		}
-	})
-}
-
-// TODO: - get rid of gross blob of global garbage
-//       - use custom events with "metautterances" to make things simpler
-
-// breadcrumbs:
-// message_part 👽 ./src/draw.js:163
-//-> convert_lang 👽 ./markup2/helpers.js:47
-//->-> Markup_Langs 👽 ./markup2/langs.js:40
-//->-> etc: {} 👽 ignored, passed on to element
-
-async function speakMessage(message, merged = false) {
-	let tree = Markup.langs.parse(message.text, message.values.m)
-	
-	let author = message.Author
-	let memorable_name = author.bridge ? (author.nickname || message.values.b) : author.username
-	let msg = merged ? "" : `${memorable_name} says\n`
-	
-	speakScript(renderSpeechScript(tree, { msg }))
-}
-
-let otherSpeechScripts = []
-async function speakScript(utter) {
-	otherSpeechScripts.push(utter)
-	if (otherSpeechScripts.length - 1)
-		await lastOfMetaUtterance(otherSpeechScripts[otherSpeechScripts.length - 2])
-	
-	for (let u of utter) {
-		if (u instanceof SpeechSynthesisUtterance) await speakUtterance(u)
-		else if (u instanceof HTMLAudioElement) await playSound(u)
-	}
-	
-	// sloppy
-	otherSpeechScripts.shift()
-}
-
-// creates a list of smaller utterances and media to play in sequence
-function renderSpeechScript(tree, opts = {}) {
-	opts.msg ||= ""
-	opts.pitch ||= 1//0.75
-	opts.rate ||= 1.5
-	opts.utter ||= []
-	// if (opts.abridged == undefined) opts.abridged = true
-	// Would it be nice to just have a way of reading the entire message without skipping over complex parts (full URLs, code blocks, tables)?
-	
-	function finalizePrev() {
-		opts.msg = opts.msg.trim()
-		if (!opts.msg.length) return
-		let u = new SpeechSynthesisUtterance(opts.msg)
-		u.pitch = opts.pitch; u.rate = opts.rate
-		opts.utter.push(u); opts.msg = ""
-	}
-	
-	// goofy way to do things
-	function simplifyUrl(s) {
-		return (s.includes("://qcs.s") && s.includes("/api/")) ? "qcs" : (new URL(s).hostname)
-	}
-	
-	for (let elem of tree.content) {
-		if ('string'==typeof elem) {
-			if (elem.length > 2500) opts.msg += "(message too long)"
-			else opts.msg += elem
-		} else if ('object'==typeof elem) switch (elem.type) {
-			case 'bold': {
-				finalizePrev()
-				renderSpeechScript(elem, {...opts, pitch: opts.pitch * 0.75})
-			break }
-			case 'italic': {
-				finalizePrev()
-				renderSpeechScript(elem, {...opts, rate: opts.rate * 0.9})
-			break }
-			case 'underline': {
-				finalizePrev()
-				renderSpeechScript(elem, {...opts, pitch: opts.pitch * 0.9, rate: opts.rate * 0.9})
-			break }
-			case 'video': {
-				opts.msg += `\nvideo from ${simplifyUrl(elem.args.url)}\n`
-			break }
-			case 'youtube': {
-				opts.msg += "\nyoutube video\n"
-			break }
-			case 'link': {
-				// depending on if they're labeled or unlabeled,
-				// i treat these as either inline or block respectively.
-				// inline being normal space pause, block being sentence break.
-				if (elem.content) {
-					renderSpeechScript(elem, opts)
-					opts.msg += " (link)"
-				} else {
-					opts.msg += elem.args.text ? ` ${elem.args.text} (link)` : `\nlink to ${simplifyUrl(elem.args.url)}\n`
-				}
-			break }
-			case 'simple_link': {
-				opts.msg += elem.args.text ? ` ${elem.args.text} (link)` : `\nlink to ${simplifyUrl(elem.args.url)}\n`
-			break }
-			case 'image': { // pretty safe bet that all images are block elements
-				opts.msg += "\n" + (elem.args.alt ? `${elem.args.alt} (image)` : `image from ${simplifyUrl(elem.args.url)}`) + "\n"
-			break }
-			case 'audio': {
-				finalizePrev()
-				opts.mediaCache ||= {}
-				opts.utter.push(opts.mediaCache[elem.args.url] ||= loadSound(elem.args.url))
-				// todo: time limite for audio?
-			break }
-			case 'code': {
-				opts.msg += '\ncode block\n' // TODO: :/
-			break }
-			case 'icode': {
-				opts.msg += elem.args.text
-			break }
-			case 'spoiler': {
-				opts.msg += "\nspoiler"
-				if (elem.args.label)
-					opts.msg += ` for ${elem.args.label}`
-				opts.msg += "\n"
-			break }
-			default: {
-				if (elem.content)
-					renderSpeechScript(elem, opts)
-				else {
-					const huh = "./resource/meow.wav"
+		
+		// goofy way to do things
+		function simplifyUrl(s) {
+			if (s.includes("://qcs.s")) return "qcs"
+			if (s.includes("cdn.discordapp.com/")) return "discord"
+			if (s.includes(" ") && !s.includes(".")) return false // silly fake link heuristics
+			if (s.includes(" ") && s.includes(".") && s.indexOf(" ") < s.indexOf(".")) return false
+			else try { return new URL(s).hostname.replace("www.", "") }
+			catch { return "invalid URL" }
+		}
+		
+		for (let elem of tree.content) {
+			if ('string'==typeof elem) {
+				if (elem.length > 2500) opts.msg += "(message too long)"
+				else opts.msg += elem
+			} else if ('object'==typeof elem) switch (elem.type) {
+				case 'bold': {
+					// TODO: is this even.. good to do?
+					finalizeChunk()
+					this.renderSpeechScript(elem, {...opts, pitch: opts.pitch * 0.75})
+					finalizeChunk()
+				break }
+				case 'italic': {
+					finalizeChunk()
+					this.renderSpeechScript(elem, {...opts, rate: opts.rate * 0.9})
+					finalizeChunk()
+				break }
+				case 'underline': {
+					finalizeChunk()
+					this.renderSpeechScript(elem, {...opts, pitch: opts.pitch * 0.9, rate: opts.rate * 0.9})
+					finalizeChunk()
+				break }
+				case 'video': {
+					opts.msg += `\nvideo from ${simplifyUrl(elem.args.url)}\n`
+				break }
+				case 'youtube': {
+					opts.msg += "\nyoutube video\n"
+				break }
+				case 'link': {
+					// depending on if they're labeled or unlabeled,
+					// i treat these as either inline or block respectively.
+					// inline being normal space pause, block being sentence break.
+					if (elem.content) {
+						this.renderSpeechScript(elem, opts)
+						opts.msg += " (link)"
+					} else {
+						opts.msg += elem.args.text ? ` ${elem.args.text} (link)` : `\nlink to ${simplifyUrl(elem.args.url)}\n`
+					}
+				break }
+				case 'simple_link': {
+					let url = simplifyUrl(elem.args.url)
+					if (!url) opts.msg += ` ${elem.args.url} (fake link)`
+					else opts.msg += elem.args.text ? ` ${elem.args.text} (link)` : `\nlink to ${url}\n`
+				break }
+				case 'image': { // pretty safe bet that all images are block elements
+					opts.msg += "\n" + (elem.args.alt ? `${elem.args.alt} (image)` : `image from ${simplifyUrl(elem.args.url)}`) + "\n"
+				break }
+				case 'audio': {
+					finalizeChunk()
 					opts.mediaCache ||= {}
-					if (opts.mediaCache[huh] == undefined)
-						opts.mediaCache[huh] = new Audio(huh)
-					console.log(`TTS Ignored ${elem.type}...`)
-				}
-			break }
+					opts.utter.push(opts.mediaCache[elem.args.url] ||= this.loadSound(elem.args.url))
+					// todo: time limite for audio?
+				break }
+				case 'code': {
+					opts.msg += "\ncode block"
+					if (elem.args.lang && elem.args.lang != 'sb') // sign of the times...
+						opts.msg += ` written in ${elem.args.lang}`
+					opts.msg += "\n"
+				break }
+				case 'icode': {
+					opts.msg += elem.args.text
+				break }
+				case 'spoiler': {
+					opts.msg += "\nspoiler"
+					if (elem.args.label)
+						opts.msg += ` for ${elem.args.label}`
+					opts.msg += "\n"
+				break }
+				default: {
+					if (elem.content)
+						this.renderSpeechScript(elem, opts)
+					else {
+						const huh = "./resource/meow.wav"
+						opts.mediaCache ||= {}
+						if (opts.mediaCache[huh] == undefined)
+							opts.mediaCache[huh] = this.loadSound(huh)
+						console.log(`TTS Ignored ${elem.type}...`)
+					}
+				break }
+			}
 		}
-	}
-	finalizePrev()
-	return opts.utter
+		
+		// if we're root elem, we probably have unfinalized stuff.
+		// finalize it and return the utterance list.
+		if (tree.type == 'ROOT') {
+			finalizeChunk()
+			return opts.utter
+		}
+	},
 }
+
+// TODO: strikethrough, sup, sub, tables (maybe read head?)

--- a/src/tts.js
+++ b/src/tts.js
@@ -78,11 +78,14 @@ const TTSSystem = {
 		let clamp01 = x=>Math.max(0, Math.min(x, 1))
 		
 		let sound = url=>{
+			if (!url) return
 			finalizeChunk()
-			let elem = opts.media[url] ||= new Audio(url)
-			elem.loop = false
-			let volume = clamp01(opts.volume)
-			opts.utter.push({ elem, volume })
+			let u = { volume: clamp01(opts.volume) }
+			if (url instanceof HTMLAudioElement) u.elem = url
+			else u.elem = opts.media[url] ||= new Audio(url)
+			u.elem.loop = false
+			opts.utter.push(u)
+			return u
 		}
 		
 		let renderWithAltParams = (elem, {volume = 1, pitch = 1, rate = 1})=>{
@@ -240,7 +243,8 @@ const TTSSystem = {
 					if (elem.content)
 						this.renderSpeechScript(elem, opts)
 					else {
-						if (this.placeholderSound) sound(this.placeholderSound)
+						// store loaded copy of placeholderSound for replaying later
+						this.placeholderSound = sound(this.placeholderSound).elem
 						console.log(`TTS renderer ignored ${elem.type}`)
 					}
 				break }

--- a/src/tts.js
+++ b/src/tts.js
@@ -1,38 +1,75 @@
-'use strict';
+'use strict'
 
-function speakThing(msg, opts) {
-	let u = new SpeechSynthesisUtterance(msg);
-	u.pitch = opts.pitch; u.rate = opts.rate;
+let TTSSystem = {}
+
+function speakUtterance(u) {
 	return new Promise((yay, nay) => {
-		// TOD: you can press it when it's already running and they'll overlap
-		u.addEventListener('end', e => (e.charIndex < e.utterance.text.length) ? nay(e) : yay());
-		u.addEventListener('error', e => nay(e));
-		speechSynthesis.speak(u);
-	});
+		u.addEventListener('end', e=>(e.charIndex < e.target.length) ? nay(e) : yay())
+		u.addEventListener('error', e=>nay(e))
+		speechSynthesis.speak(u)
+	})
+}
+
+function lastOfMetaUtterance(mu) {
+	let last = mu[mu.length - 1]
+	if (last instanceof SpeechSynthesisUtterance) {
+		return new Promise((yay, nay) => {
+			last.addEventListener('end', e=>(e.charIndex < e.target.length) ? nay(e) : yay())
+			last.addEventListener('error', e=>nay(e))
+		})
+	} else if (last instanceof HTMLAudioElement) {
+		return new Promise((yay, nay) => {
+			let removeListeners
+			
+			let c_ended = e=>yay(removeListeners())
+			let c_error = e=>nay(e,removeListeners())
+			
+			last.addEventListener('ended', c_ended)
+			last.addEventListener('', c_error)
+			last.addEventListener('error', c_error)
+			
+			removeListeners = ()=>{
+				last.removeEventListener('ended', c_ended)
+				last.removeEventListener('error', c_error)
+			}
+		})
+	}
 }
 
 function loadSound(path) {
-	return new Promise((yay, nay) => {
-		let s = new Audio(path);
-		s.addEventListener('error', e => nay(e));
-		s.addEventListener('canplaythrough', () => yay(s));
-		s.loop = false;
-		s.load();
-	});
+	let s = new Audio(path)
+	s.loop = false; s.load()
+	return s
 }
 
 function playSound(s) {
 	return new Promise((yay, nay) => {
-		s.addEventListener('error', e => nay(e))
-		s.addEventListener('ended', () => yay())
-		s.play()
+		let removeListeners
+		
+		let c_ended = e=>yay(removeListeners())
+		let c_error = e=>nay(e,removeListeners())
+		let c_loadeddata = e=>{console.log(s.readyState); return ((s.readyState >= HTMLMediaElement) && s.play())}
+		
+		s.addEventListener('ended', c_ended)
+		s.addEventListener('error', c_error)
+		
+		removeListeners = ()=>{
+			s.removeEventListener('ended', c_ended)
+			s.removeEventListener('error', c_error)
+			s.removeEventListener('loadeddata', c_loadeddata)
+		}
+		
+		if (s.readyState < HTMLMediaElement.HAVE_ENOUGH_DATA && !(s.currentTime > 0)) {
+			s.addEventListener('loadeddata', c_loadeddata)
+		} else {
+			// TODO: play a placeholder sound if sound too long (>25s?)
+			s.currentTime = 0; s.play()
+		}
 	})
 }
 
-let simplifyUrl = (s)=>(new URL(s).hostname)
-
-// if it ever errors, it should always treat that as a cancel.
-// if it recieves a cancel event, it should peace out.
+// TODO: - get rid of gross blob of global garbage
+//       - use custom events with "metautterances" to make things simpler
 
 // breadcrumbs:
 // message_part 👽 ./src/draw.js:163
@@ -40,73 +77,124 @@ let simplifyUrl = (s)=>(new URL(s).hostname)
 //->-> Markup_Langs 👽 ./markup2/langs.js:40
 //->-> etc: {} 👽 ignored, passed on to element
 
-async function speakMessage(message) {
+async function speakMessage(message, merged = false) {
 	let tree = Markup.langs.parse(message.text, message.values.m)
-	let opts = { pitch: 0.75, rate: 1.5 }
-	speechSynthesis.cancel()
-	await speakThing(`${message.Author.bridge ? message.Author.nickname : message.Author.username} says:`, opts)
-	await speakTree(tree, opts)
+	
+	let author = message.Author
+	let memorable_name = author.bridge ? (author.nickname || message.values.b) : author.username
+	let msg = merged ? "" : `${memorable_name} says\n`
+	
+	speakScript(renderSpeechScript(tree, { msg }))
 }
 
-async function speakTree(tree, opts = {}) {
-	(opts.playing == undefined) && (opts.playing = true)
-	opts.mediaCache ||= {}
+let otherSpeechScripts = []
+async function speakScript(utter) {
+	otherSpeechScripts.push(utter)
+	if (otherSpeechScripts.length - 1)
+		await lastOfMetaUtterance(otherSpeechScripts[otherSpeechScripts.length - 2])
+	
+	for (let u of utter) {
+		if (u instanceof SpeechSynthesisUtterance) await speakUtterance(u)
+		else if (u instanceof HTMLAudioElement) await playSound(u)
+	}
+	
+	// sloppy
+	otherSpeechScripts.shift()
+}
+
+// creates a list of smaller utterances and media to play in sequence
+function renderSpeechScript(tree, opts = {}) {
+	opts.msg ||= ""
+	opts.pitch ||= 1//0.75
+	opts.rate ||= 1.5
+	opts.utter ||= []
+	// if (opts.abridged == undefined) opts.abridged = true
+	// Would it be nice to just have a way of reading the entire message without skipping over complex parts (full URLs, code blocks, tables)?
+	
+	function finalizePrev() {
+		opts.msg = opts.msg.trim()
+		if (!opts.msg.length) return
+		let u = new SpeechSynthesisUtterance(opts.msg)
+		u.pitch = opts.pitch; u.rate = opts.rate
+		opts.utter.push(u); opts.msg = ""
+	}
+	
+	// goofy way to do things
+	function simplifyUrl(s) {
+		return (s.includes("://qcs.s") && s.includes("/api/")) ? "qcs" : (new URL(s).hostname)
+	}
+	
 	for (let elem of tree.content) {
-		if (typeof elem == 'string') {
-			await speakThing(elem, opts)
-		} else if (typeof elem == 'object') switch (elem.type) {
+		if ('string'==typeof elem) {
+			if (elem.length > 2500) opts.msg += "(message too long)"
+			else opts.msg += elem
+		} else if ('object'==typeof elem) switch (elem.type) {
 			case 'bold': {
-				let prev = opts.pitch
-				opts.pitch *= 0.85
-				speakTree(elem, opts)
-				opts.pitch = prev
-			} break
+				finalizePrev()
+				renderSpeechScript(elem, {...opts, pitch: opts.pitch * 0.75})
+			break }
 			case 'italic': {
-				let prev = opts.rate
-				opts.rate *= 0.85
-				speakTree(elem, opts)
-				opts.rate = prev
-			} break
+				finalizePrev()
+				renderSpeechScript(elem, {...opts, rate: opts.rate * 0.9})
+			break }
+			case 'underline': {
+				finalizePrev()
+				renderSpeechScript(elem, {...opts, pitch: opts.pitch * 0.9, rate: opts.rate * 0.9})
+			break }
 			case 'video': {
-				await speakThing(`video from ${simplifyURL(elem.args.url)}`, opts)
-			} break
+				opts.msg += `\nvideo from ${simplifyUrl(elem.args.url)}\n`
+			break }
 			case 'youtube': {
-				await speakThing("youtube video", opts)
-			} break
+				opts.msg += "\nyoutube video\n"
+			break }
 			case 'link': {
-				console.log(elem);
+				// depending on if they're labeled or unlabeled,
+				// i treat these as either inline or block respectively.
+				// inline being normal space pause, block being sentence break.
 				if (elem.content) {
-					speakTree(elem, opts) // 🥴
-					await speakThing("(link)", opts)
+					renderSpeechScript(elem, opts)
+					opts.msg += " (link)"
 				} else {
-					let s = "";
-					elem.args.text ? `${elem.args.text} (link)` : `link to ${simplifyUrl(elem.args.url)}`
-					await speakThing(s, opts)
+					opts.msg += elem.args.text ? ` ${elem.args.text} (link)` : `\nlink to ${simplifyUrl(elem.args.url)}\n`
 				}
-			} break
+			break }
 			case 'simple_link': {
-				console.log(elem);
-				let s = elem.args.text ? `${elem.args.text} (link)` : `link to ${simplifyUrl(elem.args.url)}`
-				await speakThing(s, opts)
-			} break
-			case 'image': {
-				let s = elem.args.alt ? `${elem.args.alt} (image)` : `image from ${simplifyUrl(elem.args.url)}`
-				await speakThing(s, opts)
-			} break
+				opts.msg += elem.args.text ? ` ${elem.args.text} (link)` : `\nlink to ${simplifyUrl(elem.args.url)}\n`
+			break }
+			case 'image': { // pretty safe bet that all images are block elements
+				opts.msg += "\n" + (elem.args.alt ? `${elem.args.alt} (image)` : `image from ${simplifyUrl(elem.args.url)}`) + "\n"
+			break }
 			case 'audio': {
-				await playSound(opts.mediaCache[elem.args.url] ||= await loadSound(elem.args.url))
-			} break
+				finalizePrev()
+				opts.mediaCache ||= {}
+				opts.utter.push(opts.mediaCache[elem.args.url] ||= loadSound(elem.args.url))
+				// todo: time limite for audio?
+			break }
+			case 'code': {
+				opts.msg += '\ncode block\n' // TODO: :/
+			break }
+			case 'icode': {
+				opts.msg += elem.args.text
+			break }
+			case 'spoiler': {
+				opts.msg += "\nspoiler"
+				if (elem.args.label)
+					opts.msg += ` for ${elem.args.label}`
+				opts.msg += "\n"
+			break }
 			default: {
 				if (elem.content)
-					speakTree(elem, opts)
+					renderSpeechScript(elem, opts)
 				else {
-					const huh = "./resource/meow.wav";
+					const huh = "./resource/meow.wav"
+					opts.mediaCache ||= {}
 					if (opts.mediaCache[huh] == undefined)
-						opts.mediaCache[huh] = await loadSound(huh)
-					await playSound(opts.mediaCache[huh])
-					console.log(`Ignored ${elem.type}...`)
+						opts.mediaCache[huh] = new Audio(huh)
+					console.log(`TTS Ignored ${elem.type}...`)
 				}
-			} break
+			break }
 		}
 	}
+	finalizePrev()
+	return opts.utter
 }

--- a/src/tts.js
+++ b/src/tts.js
@@ -1,0 +1,112 @@
+'use strict';
+
+function speakThing(msg, opts) {
+	let u = new SpeechSynthesisUtterance(msg);
+	u.pitch = opts.pitch; u.rate = opts.rate;
+	return new Promise((yay, nay) => {
+		// TOD: you can press it when it's already running and they'll overlap
+		u.addEventListener('end', e => (e.charIndex < e.utterance.text.length) ? nay(e) : yay());
+		u.addEventListener('error', e => nay(e));
+		speechSynthesis.speak(u);
+	});
+}
+
+function loadSound(path) {
+	return new Promise((yay, nay) => {
+		let s = new Audio(path);
+		s.addEventListener('error', e => nay(e));
+		s.addEventListener('canplaythrough', () => yay(s));
+		s.loop = false;
+		s.load();
+	});
+}
+
+function playSound(s) {
+	return new Promise((yay, nay) => {
+		s.addEventListener('error', e => nay(e))
+		s.addEventListener('ended', () => yay())
+		s.play()
+	})
+}
+
+let simplifyUrl = (s)=>(new URL(s).hostname)
+
+// if it ever errors, it should always treat that as a cancel.
+// if it recieves a cancel event, it should peace out.
+
+// breadcrumbs:
+// message_part 👽 ./src/draw.js:163
+//-> convert_lang 👽 ./markup2/helpers.js:47
+//->-> Markup_Langs 👽 ./markup2/langs.js:40
+//->-> etc: {} 👽 ignored, passed on to element
+
+async function speakMessage(message) {
+	let tree = Markup.langs.parse(message.text, message.values.m)
+	let opts = { pitch: 0.75, rate: 1.5 }
+	speechSynthesis.cancel()
+	await speakThing(`${message.Author.bridge ? message.Author.nickname : message.Author.username} says:`, opts)
+	await speakTree(tree, opts)
+}
+
+async function speakTree(tree, opts = {}) {
+	(opts.playing == undefined) && (opts.playing = true)
+	opts.mediaCache ||= {}
+	for (let elem of tree.content) {
+		if (typeof elem == 'string') {
+			await speakThing(elem, opts)
+		} else if (typeof elem == 'object') switch (elem.type) {
+			case 'bold': {
+				let prev = opts.pitch
+				opts.pitch *= 0.85
+				speakTree(elem, opts)
+				opts.pitch = prev
+			} break
+			case 'italic': {
+				let prev = opts.rate
+				opts.rate *= 0.85
+				speakTree(elem, opts)
+				opts.rate = prev
+			} break
+			case 'video': {
+				await speakThing(`video from ${simplifyURL(elem.args.url)}`, opts)
+			} break
+			case 'youtube': {
+				await speakThing("youtube video", opts)
+			} break
+			case 'link': {
+				console.log(elem);
+				if (elem.content) {
+					speakTree(elem, opts) // 🥴
+					await speakThing("(link)", opts)
+				} else {
+					let s = "";
+					elem.args.text ? `${elem.args.text} (link)` : `link to ${simplifyUrl(elem.args.url)}`
+					await speakThing(s, opts)
+				}
+			} break
+			case 'simple_link': {
+				console.log(elem);
+				let s = elem.args.text ? `${elem.args.text} (link)` : `link to ${simplifyUrl(elem.args.url)}`
+				await speakThing(s, opts)
+			} break
+			case 'image': {
+				let s = elem.args.alt ? `${elem.args.alt} (image)` : `image from ${simplifyUrl(elem.args.url)}`
+				await speakThing(s, opts)
+			} break
+			case 'audio': {
+				await playSound(opts.mediaCache[elem.args.url] ||= await loadSound(elem.args.url))
+			} break
+			default: {
+				if (elem.content)
+					speakTree(elem, opts)
+				else {
+					const huh = "./resource/meow.wav";
+					if (opts.mediaCache[huh] == undefined)
+						opts.mediaCache[huh] = await loadSound(huh)
+					await playSound(opts.mediaCache[huh])
+					console.log(`Ignored ${elem.type}...`)
+				}
+			} break
+		}
+	}
+}

--- a/src/tts.js
+++ b/src/tts.js
@@ -192,9 +192,9 @@ const TTSSystem = {
 						this.renderSpeechScript(elem, opts)
 					else {
 						const huh = "./resource/meow.wav"
+						finalizeChunk()
 						opts.mediaCache ||= {}
-						if (opts.mediaCache[huh] == undefined)
-							opts.mediaCache[huh] = this.loadSound(huh)
+						opts.utter.push(opts.mediaCache[huh] ||= this.loadSound(huh))
 						console.log(`TTS Ignored ${elem.type}...`)
 					}
 				break }
@@ -210,4 +210,8 @@ const TTSSystem = {
 	},
 }
 
-// TODO: strikethrough, sup, sub, tables (maybe read head?)
+// TODO: strikethrough, sup, sub, tables (maybe read head?),
+//       ruby (true already handled), horiz. rule, maybe lists,
+//       maybe headers? (louder volume?), quote text (with barely-used src),
+//       maybe anchors should work (as in `[[#test]]`),
+// (from quick run through of 12y markup guide and glance at comments)


### PR DESCRIPTION
via a slightly over-engineered markup "renderer"

- Adds automatic reading of chat messages, reading link text and image descriptions and such
  - and an option to ignore your own messages but read everyone else's
- Adds shift-clicking ⚙ to listen to an old message
- Once, I turned my phone screen off and it still worked
- Plays audio files in chat messages (regardless of their length 🙂)
- Adds a "Stop TTS" button and TTS-related options to the user tab:
  - ![2022-07-10_03-27-16_firefox](https://user-images.githubusercontent.com/25177071/178135439-f907b5a4-b98f-4876-badd-bd45a7ffd33a.png)
  - "Stop TTS" button shows how many messages left, on hover
  - TTS options will say example message when you change their value

fixed issues:
- placeholder sound (if any) was not cached across messages
- TTS says example message when you click `Update sitejs/sitecss`