### PR TITLE
Link visited colour provided for Dark theme

### DIFF
--- a/src/theme.css
+++ b/src/theme.css
@@ -18,6 +18,7 @@
 	--T-color: #000;
 	--T-link-color: #045;
 	--T-link-hover-color: #009688;
+	--T-link-visited-color: #606;
 	--T-link-bg: #E5E5FF;
 	--T-time-color: #333;
 	--T-border-color: #808080;
@@ -76,6 +77,7 @@
 	caret-color: var(--T-color);
 	--T-color: #FFF;
 	--T-link-color: #9CE;
+	--T-link-visited-color: #9365bc;
 	--T-link-hover-color: #5CE;
 	--T-link-bg: #156;
 	--T-time-color: #EEE;


### PR DESCRIPTION
As a result of a new CSS variable for highlighting the link when it's visited, the default colour has only been assumed for the Light theme since this change hasn't been synchronised into the frontend yet.

`--T-link-visited-color` has been provided for both the light theme (set to the default colour) and the dark theme (set to its own custom colour that's better suited for dark themes)

Old:
![image](https://user-images.githubusercontent.com/18371895/205455829-e5b42834-fba2-46b0-911e-958ff9b840a4.png)

New:
<img width="183" alt="Screenshot 2022-12-03 at 1 17 23 PM" src="https://user-images.githubusercontent.com/18371895/205455821-bc574bdc-dd8b-4113-a9cc-e1aaa51890f4.png">
