### PR TITLE
Check user groups when determining if can post

### DIFF
--- a/src/Views/page.js
+++ b/src/Views/page.js
@@ -139,7 +139,9 @@ class PageView extends BaseView {
 		
 		//let can_edit = /u/i.test(page.permissions[Req.uid]) // unused
 		
-		let can_talk = page.createUserId==Req.uid || Entity.has_perm(page.permissions, Req.uid, 'C')
+		// You don't need to check createUser, the page always has the correct
+		// permissions (createUser always full perms in page.permissions regardless)
+		let can_talk = Entity.user_has_perm(page.permissions, Req.me, 'C')
 		this.$textarea.disabled = !can_talk
 		if (can_talk)
 			this.$textarea.focus()

--- a/src/entity.js
+++ b/src/entity.js
@@ -187,6 +187,15 @@ const Entity = NAMESPACE({
 			return true
 		return perms[uid] && perms[uid].includes(perm)
 	},
+	user_has_perm(perms, user, perm) {
+		if (user.groups) {
+			for(let group of user.groups) {
+				if (this.has_perm(perms, group, perm))
+					return true
+			}
+		}
+		return this.has_perm(perms, user.id, perm)
+	},
 	
 	// should this return null?
 	// I'm not sure how this should work exactly


### PR DESCRIPTION
I added a new function "user_has_perm" which you should call if you have the whole user object and want to know if they can do the thing. Of course, that user object needs to have the `groups` field (it checks for it), but that's returned by default in `/api/user/me` anyway...