### PR TITLE
New rethreading metadata

### DIFF
--- a/src/messages.js
+++ b/src/messages.js
@@ -58,6 +58,25 @@ class MessageList {
 		}
 	}
 	
+	// Added to showcase how to detect a rethreaded message, and what you might want to show below the message
+	// part. But I didn't know how you wanted to handle the display, so I only log it to the console. Feel
+	// free to do whatever with the message! y wants to see it!
+	draw_rethread(msg) {
+		// Fields are 'date', 'count', 'position' (start or end, or 'start|end' if single message), and 'lastContentId'.
+		// Generally, 'lastContentId' is enough, but you may want to display where it came from originally if the value
+		// differs from 'originalContentId'. See: https://github.com/randomouscrap98/contentapi/wiki/Breaking-Changes#december-19th-2022
+		var r = msg.values.rethread
+		var rethread = document.createElement("div")
+		rethread.className = "rethread"
+		rethread.innerHTML = `${r.position.toUpperCase()}: Rethreaded ${r.count} messages from <a href="#page/${r.lastContentId}" target="_blank">page ${r.lastContentId}</a>`
+		if(r.lastContentId !== msg.values.originalContentId)
+			rethread.innerHTML += ` (orig: <a href="#page/${msg.values.originalContentId}" target="_blank">page ${msg.values.originalContentId}</a>)`
+		rethread.innerHTML += ` - ${(new Date(r.date)).toLocaleString()}`
+		fragment.appendChild(rethread)
+
+		return rethread
+	}
+
 	// draw a message
 	// msg: Message
 	// return: Element
@@ -67,6 +86,9 @@ class MessageList {
 		if (msg.edited)
 			e.className += " edited"
 		Markup.convert_lang(msg.text, msg.values.m, e, {intersection_observer: View.observer})
+		// Do something with the rethread info! 
+		if(msg.values.rethread)
+			console.log(draw_rethread(msg))
 		return e
 	}
 	// draw a message and insert it into the linked list

--- a/src/messages.js
+++ b/src/messages.js
@@ -72,7 +72,6 @@ class MessageList {
 		if(r.lastContentId !== msg.values.originalContentId)
 			rethread.innerHTML += ` (orig: <a href="#page/${msg.values.originalContentId}" target="_blank">page ${msg.values.originalContentId}</a>)`
 		rethread.innerHTML += ` - ${(new Date(r.date)).toLocaleString()}`
-		fragment.appendChild(rethread)
 
 		return rethread
 	}

--- a/src/messages.js
+++ b/src/messages.js
@@ -65,29 +65,50 @@ class MessageList {
 		// Fields are 'date', 'count', 'position' (start or end, or 'start|end' if single message), and 'lastContentId'.
 		// Generally, 'lastContentId' is enough, but you may want to display where it came from originally if the value
 		// differs from 'originalContentId'. See: https://github.com/randomouscrap98/contentapi/wiki/Breaking-Changes#december-19th-2022
-		var r = msg.values.rethread
-		var rethread = document.createElement("div")
-		rethread.className = "rethread"
-		rethread.innerHTML = `${r.position.toUpperCase()}: Rethreaded ${r.count} messages from <a href="#page/${r.lastContentId}" target="_blank">page ${r.lastContentId}</a>`
-		if(r.lastContentId !== msg.values.originalContentId)
-			rethread.innerHTML += ` (orig: <a href="#page/${msg.values.originalContentId}" target="_blank">page ${msg.values.originalContentId}</a>)`
-		rethread.innerHTML += ` - ${(new Date(r.date)).toLocaleString()}`
-
-		return rethread
+		/* if you didn't make your html templating system so hard to use outside your
+		 * slot thing maybe i could actually use it. but here we ar e >:(.
+		 * making this your responsibility to refactor :smile: */
+		const { rethread:r } = msg.values
+		const e = 𐀶`<div class=rethread>
+			<span></span>: Rethreaded <span></span> messages from <a target="_blank"></a>
+			<span></span>
+			<span role=time></span>
+		</div>`()
+		e.children[0].innerText = r.position.toUpperCase()
+		e.children[1].innerText = r.count
+		const pageLink = e.children[2]
+		pageLink.href = `#page/${r.lastContentId}`
+		pageLink.innerText = `page ${r.lastContentId}`
+		if (r.lastContentId !== msg.values.originalContentId) {
+			const origE = 𐀶`<span>(orig: <a target="_blank"></a>)</span>`()
+			const origPageLink = origE.firstChild
+			origPageLink.href = `#page/${msg.values.originalContentId}`
+			origPageLink.innerText = `page ${msg.value.originalContentId}`
+			e.children[3].fill(origE)
+		}
+		e.children[4].innerText = ` - ${(new Date(r.date)).toLocaleString()}`
+		return e
 	}
 
 	// draw a message
 	// msg: Message
 	// return: Element
 	draw_part(msg) {	
-		let e = MessageList.part_template()
+		const e = MessageList.part_template()
+		const extraTop = e.children[0]
+		const content = e.children[1]
+		const extraBottom = e.children[2]
 		e.dataset.id = msg.id
 		if (msg.edited)
 			e.className += " edited"
-		Markup.convert_lang(msg.text, msg.values.m, e, {intersection_observer: View.observer})
+		Markup.convert_lang(msg.text, msg.values.m, content, {intersection_observer: View.observer})
 		// Do something with the rethread info! 
-		if(msg.values.rethread)
-			console.log(draw_rethread(msg))
+		if(msg.values.rethread) {
+			const position = msg.values.rethread.position.toUpperCase()
+			const rethread = this.draw_rethread(msg)
+			const extra = (position === "START" ? extraTop : extraBottom)
+			extra.fill(rethread)
+		}
 		return e
 	}
 	// draw a message and insert it into the linked list
@@ -355,7 +376,11 @@ class MessageList {
 		}
 	}
 }
-MessageList.part_template = 𐀶`<message-part role=listitem>`
+MessageList.part_template = 𐀶`<message-part role=listitem>
+	<div></div>
+	<div></div>
+	<div></div>
+</message-part>`
 MessageList.controls = null
 MessageList.controls_message = null
 MessageList.prototype.max_parts = 500

--- a/src/style.css
+++ b/src/style.css
@@ -725,6 +725,14 @@ message-controls:hover + message-part {
 	background: var(--message-hover-bg);
 }
 
+.rethread {
+	font-style: italic;
+	color: var(--chat-dim-color);
+	margin: 0.25em;
+	padding: 0.25em;
+	border: 1px solid var(--T-border-color);
+}
+
 /* chat input pane */
 .inputPane {
 	background: var(--bar-bg);


### PR DESCRIPTION
The API now automatically stamps the start and end message of a rethread with rethread metadata. It is already in production, so it's ready to be used. On my frontend, it looks something like:

![haloopdy_frontend_rethread](https://qcs.shsbs.xyz/api/file/raw/mwlio)
(a rethread of just three messages)

You can see all the information here: https://github.com/randomouscrap98/contentapi/wiki/Breaking-Changes#december-19th-2022, but to summarize:
- When a rethread happens, the first and last messages are stamped with a `rethread` object in the values, that looks like:
```json
"values" : {
  "rethread" : {
    "date":"rethread_date",
    "count":11,
    "position":"start|end",
    "lastContentId":123
  }
}
```
- Furthermore, ALL messages that are part of the rethread get stamped with an `originalContentId` which never changes, even if the message gets rethreaded over and over
- Thus, the `rethread` value is updated for the start and end messages anytime a rethread occurs, but `originalContentId` is stamped once and thus will always tell you the original room a message was posted in

I've added code to your frontend in this pull request which will render the same annotation as my frontend, just a simple div with some links (but reformatted for your link format). However, I did NOT actually display it anywhere, instead I log it, because I don't know what you want to do with it. It IS part of a "message-part", but it seems difficult to insert anywhere. Maybe as its own element between message parts? I feel like that might break stuff, so I wanted to leave that up to you. Also, feel free to change the formatting or completely rewrite the `draw_rethread` function. I display the alternate original post if the original post does not equal the lastContentId, I think this is an important usability mode which will likely never happen, but it's up to you how you want to handle that. Basically, all the cases should be handled by that display code, and that `if` statement in `draw_part` should be all you need to detect a rethread.

Again, feel free to completely change the whole thing, it won't bother me!