### PR TITLE
Seperate markup from page data to properly affect preview

### DIFF
--- a/src/Views/editpage.js
+++ b/src/Views/editpage.js
@@ -28,6 +28,7 @@ class EditView extends BaseView {
 			data.keywords = this.$edit_keywords.value.match(/[^,\s]+/g) || []
 			data.name = this.$edit_name.value
 			data.literalType = this.$edit_type.value
+			data.values.markupLang = this.$edit_markup.value || "plaintext"
 			
 			let text
 			if (this.current_section == null) {
@@ -189,6 +190,10 @@ class EditView extends BaseView {
 					writable[k] = v
 			}
 		}
+		if (writable.values && writable.values.markupLang) {
+			this.$edit_markup.value = page.values.markupLang || "plaintext"
+			delete writable.values.markupLang
+		}
 		this.$data.value = JSON.stringify(writable, null, 1)
 		this.$edit_keywords.value = page.keywords.join(" ")
 		this.$edit_name.value = page.name
@@ -241,7 +246,7 @@ class EditView extends BaseView {
 	}
 	update_preview(full) {
 		let shouldScroll = this.$preview_outer.scrollHeight-this.$preview_outer.clientHeight-this.$preview_outer.scrollTop
-		Markup.convert_lang(this.$textarea.value, this.page.values.markupLang, this.$preview, {preview: !full})
+		Markup.convert_lang(this.$textarea.value, this.$edit_markup.value, this.$preview, {preview: !full})
 		//console.log(shouldScroll, 'scr?')
 		if (shouldScroll < 20)
 			this.$preview_outer.scrollTop = 9e9
@@ -280,6 +285,7 @@ EditView.template = HTML`
 			<label class='edit-field'>Title:<input $=edit_name></label>
 			<label class='edit-field'>Kind:<input $=edit_type placeholder=literalType></label>
 			<label class='edit-field'>Keywords:<input $=edit_keywords style=word-spacing:0.5em></label>
+			<label class='edit-field'>Markup:<input $=edit_markup placeholder=markupLang></label>
 			<textarea $=data style="resize:none;" class='FILL code-textarea'></textarea>
 		</div>
 	</div>


### PR DESCRIPTION
This takes the markupLang attribute for the page out of the writable fields and places it into a seperate field like for "Keywords" and "Kind" so that we can detect its changes for the preview.

![image](https://user-images.githubusercontent.com/18371895/209144778-f89d2ec4-0772-421e-8a82-cc9b53b99564.png)

This closes #48
