### PR TITLE
Add `?localhost=<port>` options for logging into a local instance

### DIFF
--- a/index.html
+++ b/index.html
@@ -266,6 +266,7 @@
 			</div>
 			<div class='loggedOut registerBox'>
 				<h2>Log In</h2>
+				<div id=$loginPlace></div>
 				<form id=$loginForm method=dialog>
 					<input placeholder=Username name=username><br>
 					<br id=$login_password><br>

--- a/src/navigate.js
+++ b/src/navigate.js
@@ -403,10 +403,17 @@ const Nav = NAMESPACE({
 	
 	start() {
 		// send users at ?page/123 to #page/123
-		if (window.location.hash=="" && window.location.search.length>1 && !window.location.search.startsWith("?dev")) {
+		if (window.location.hash=="" && window.location.search.length>1) {
 			let x = new URL(window.location)
-			x.hash = "#"+x.search.substring(1)
-			x.search = ""
+			const [localhost, dev] = [
+				x.searchParams.get('localhost'),
+				x.searchParams.has('dev')
+			]
+			x.searchParams.delete('localhost')
+			x.searchParams.delete('dev')
+			x.hash = "#"+x.search
+			if (localhost) x.searchParams.set('localhost', localhost)
+			if (dev) x.searchParams.set('dev')
 			window.history.replaceState(null, "sbs2", x.href)
 		}
 		

--- a/src/navigate.js
+++ b/src/navigate.js
@@ -405,15 +405,15 @@ const Nav = NAMESPACE({
 		// send users at ?page/123 to #page/123
 		if (window.location.hash=="" && window.location.search.length>1) {
 			let x = new URL(window.location)
-			const [localhost, dev] = [
+			const [localhost, api] = [
 				x.searchParams.get('localhost'),
-				x.searchParams.has('dev')
+				x.searchParams.has('api')
 			]
 			x.searchParams.delete('localhost')
-			x.searchParams.delete('dev')
+			x.searchParams.delete('api')
 			x.hash = "#"+x.search
 			if (localhost) x.searchParams.set('localhost', localhost)
-			if (dev) x.searchParams.set('dev')
+			if (api) x.searchParams.set('api')
 			window.history.replaceState(null, "sbs2", x.href)
 		}
 		

--- a/src/request.js
+++ b/src/request.js
@@ -143,9 +143,9 @@ const Req = { // this stuff can all be static methods on ApiRequest maybe?
 	ws_protocol: OPTS.has('localhost') ? 'ws://' : 'wss://',
 	server: OPTS.has('localhost')
 		? `localhost:${OPTS.get('localhost')}/api`
-		: OPTS.has('dev')
-			? "oboy.smilebasicsource.com/api"
-			: "qcs.shsbs.xyz/api",
+		: OPTS.has('api')
+			? `${OPTS.get('api')}/api`
+			: 'qcs.shsbs.xyz/api',
 	
 	get storage_key() {
 		return `token-${this.server}`

--- a/src/request.js
+++ b/src/request.js
@@ -61,7 +61,7 @@ class ApiRequest extends XMLHttpRequest {
 		throw err
 	}
 	go() {
-		this.open(this.method, `https://${Req.server}/${this.url}`)
+		this.open(this.method, `${Req.protocol}${Req.server}/${this.url}`)
 		this.setRequestHeader('CACHE-CONTROL', "L, ratio, no-store, no-cache, must-revalidate") // we probably only need no-store here
 		if (Req.auth)
 			this.setRequestHeader('AUTHORIZATION', "Bearer "+Req.auth)
@@ -139,8 +139,13 @@ ${resp}`)
 }
 
 const Req = { // this stuff can all be static methods on ApiRequest maybe?
-	server: OPTS.has('dev') ?
-		"oboy.smilebasicsource.com/api" : "qcs.shsbs.xyz/api",
+	protocol: OPTS.has('localhost') ? 'http://' : 'https://',
+	ws_protocol: OPTS.has('localhost') ? 'ws://' : 'wss://',
+	server: OPTS.has('localhost')
+		? `localhost:${OPTS.get('localhost')}/api`
+		: OPTS.has('dev')
+			? "oboy.smilebasicsource.com/api"
+			: "qcs.shsbs.xyz/api",
 	
 	get storage_key() {
 		return `token-${this.server}`
@@ -221,7 +226,7 @@ const Req = { // this stuff can all be static methods on ApiRequest maybe?
 	},
 	
 	image_url(id, size, crop) {
-		let url = `https://${this.server}/File/raw/${id}`
+		let url = `${this.protocol}${this.server}/File/raw/${id}`
 		if (size) {
 			url += `?size=${size}`
 			if (crop)

--- a/src/sidebar.js
+++ b/src/sidebar.js
@@ -84,6 +84,7 @@ const Sidebar = NAMESPACE({
 		})
 		View.bind_enter($searchInput, $searchButton.onclick)
 		$login_password.replaceWith(Draw.password_input('password'))
+		$loginPlace.textContent = Req.server.split('/api', 1)[0]
 		$loginForm.onsubmit = ev=>{
 			ev.preventDefault()
 			Req.get_auth($loginForm.username.value, $loginForm.password.value, $loginForm.long.checked).do = (resp, err)=>{

--- a/src/socket.js
+++ b/src/socket.js
@@ -239,7 +239,7 @@ const Lp = NAMESPACE({
 		this.last_reconnect = Date.now()
 		this.fails++
 		
-		this.websocket = new WebSocket(`wss://${Req.server}/live/ws?lastId=${this.last_id}&token=${encodeURIComponent(Req.auth)}`)
+		this.websocket = new WebSocket(`${Req.ws_protocol}${Req.server}/live/ws?lastId=${this.last_id}&token=${encodeURIComponent(Req.auth)}`)
 		this.message_count = 0
 		this.state_change('opening')
 		


### PR DESCRIPTION
- Any need for a more general `?api=<url>` too? (This would not do the same `wss:`→`ws:` reconfiguration that `?localhost` would do)